### PR TITLE
Centralize credential management

### DIFF
--- a/thepool/00-removetheextra.aspx.cs
+++ b/thepool/00-removetheextra.aspx.cs
@@ -31,7 +31,7 @@ public partial class _00_removetheextra : System.Web.UI.Page
 
     private void LoadData()
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.PoolConnectionString;
         List<Entry> entries = new List<Entry>();
 
         using (MySqlConnection connection = new MySqlConnection(connectionString))
@@ -85,7 +85,7 @@ public partial class _00_removetheextra : System.Web.UI.Page
     [WebMethod]
     public static string DeleteRow(int id)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.PoolConnectionString;
 
         using (MySqlConnection connection = new MySqlConnection(connectionString))
         {

--- a/thepool/2017/01-weekone.aspx.cs
+++ b/thepool/2017/01-weekone.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2017_01_weekone : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk1);

--- a/thepool/2017/02-secondweek.aspx.cs
+++ b/thepool/2017/02-secondweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2017_02_secondweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/03-thirdwk.aspx.cs
+++ b/thepool/2017/03-thirdwk.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2017_03_thirdwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/04-4thwk.aspx.cs
+++ b/thepool/2017/04-4thwk.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_04_4thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/05-week5.aspx.cs
+++ b/thepool/2017/05-week5.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_05_week5 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/06-6thweek.aspx.cs
+++ b/thepool/2017/06-6thweek.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_06_6thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/07-seven.aspx.cs
+++ b/thepool/2017/07-seven.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_07_seven : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/08-8thweek.aspx.cs
+++ b/thepool/2017/08-8thweek.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_08_8thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/09-9thwk.aspx.cs
+++ b/thepool/2017/09-9thwk.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_09_9thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/10-tenthwk.aspx.cs
+++ b/thepool/2017/10-tenthwk.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_10_tenthwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/11-eleven.aspx.cs
+++ b/thepool/2017/11-eleven.aspx.cs
@@ -82,7 +82,7 @@ public partial class thepool_2017_11_eleven : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/12-thanksgivingweek.aspx.cs
+++ b/thepool/2017/12-thanksgivingweek.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_12_thanksgivingweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/13-wk13.aspx.cs
+++ b/thepool/2017/13-wk13.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_13_wk13 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/14-weekfourteen.aspx.cs
+++ b/thepool/2017/14-weekfourteen.aspx.cs
@@ -82,7 +82,7 @@ public partial class _2017_14_weekfourteen : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/15-week15.aspx.cs
+++ b/thepool/2017/15-week15.aspx.cs
@@ -85,7 +85,7 @@ public partial class _2017_15_week15 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/16-sweet16.aspx.cs
+++ b/thepool/2017/16-sweet16.aspx.cs
@@ -85,7 +85,7 @@ public partial class _2017_16_sweet16 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2017/17-17thweek17.aspx.cs
+++ b/thepool/2017/17-17thweek17.aspx.cs
@@ -81,7 +81,7 @@ public partial class _2017_17_17thweek17 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/01-week1-18.aspx.cs
+++ b/thepool/2018/01-week1-18.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_01_week1_18 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/02-weektwo.aspx.cs
+++ b/thepool/2018/02-weektwo.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_02_weektwo : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/03-3rdweek.aspx.cs
+++ b/thepool/2018/03-3rdweek.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_03_3rdweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/04-4thwk.aspx.cs
+++ b/thepool/2018/04-4thwk.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_04_4thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/05-5thweek5.aspx.cs
+++ b/thepool/2018/05-5thweek5.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_05_5thweek5 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/06-6th-week.aspx.cs
+++ b/thepool/2018/06-6th-week.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_06_6th_week : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/07-7seventhweek.aspx.cs
+++ b/thepool/2018/07-7seventhweek.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_07_7seventhweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/08-8thwk.aspx.cs
+++ b/thepool/2018/08-8thwk.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_08_8thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/09-9nine.aspx.cs
+++ b/thepool/2018/09-9nine.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_09_9nine : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/10-10thwk18.aspx.cs
+++ b/thepool/2018/10-10thwk18.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_10_10thwk18 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/11-eleven.aspx.cs
+++ b/thepool/2018/11-eleven.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_11_eleven : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/12-12thweek.aspx.cs
+++ b/thepool/2018/12-12thweek.aspx.cs
@@ -83,7 +83,7 @@ public partial class _2018_12_12thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/13-13thwk.aspx.cs
+++ b/thepool/2018/13-13thwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2018_13_13thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/14-14thweek2018.aspx.cs
+++ b/thepool/2018/14-14thweek2018.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2018_14_14thweek2018 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/15-15th2018.aspx.cs
+++ b/thepool/2018/15-15th2018.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2018_15_15th2018 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/16-16thwk2018.aspx.cs
+++ b/thepool/2018/16-16thwk2018.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2018_16_16thwk2018 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/17-17thweek2018.aspx.cs
+++ b/thepool/2018/17-17thweek2018.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2018_17_17thweek2018 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2018/18-TestWeek.aspx.cs
+++ b/thepool/2018/18-TestWeek.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2018_18_TestWeek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/01-firstwk2019.aspx.cs
+++ b/thepool/2019/01-firstwk2019.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_01_firstwk2019 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/02-second2019.aspx.cs
+++ b/thepool/2019/02-second2019.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_02_second2019 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/03-3rdwk.aspx.cs
+++ b/thepool/2019/03-3rdwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_03_3rdwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/04-weekfour.aspx.cs
+++ b/thepool/2019/04-weekfour.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_04_weekfour : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/05-5thweek.aspx.cs
+++ b/thepool/2019/05-5thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_05_5thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/06-wksix.aspx.cs
+++ b/thepool/2019/06-wksix.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_06_wksix : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/07-seventhwk.aspx.cs
+++ b/thepool/2019/07-seventhwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_07_seventhwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/08-weekeight.aspx.cs
+++ b/thepool/2019/08-weekeight.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_08_weekeight : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/09-09test.aspx.cs
+++ b/thepool/2019/09-09test.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_09_09test : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/09-wknine.aspx.cs
+++ b/thepool/2019/09-wknine.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_09_wknine : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/10-10thweek.aspx.cs
+++ b/thepool/2019/10-10thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_10_10thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/11-eleven.aspx.cs
+++ b/thepool/2019/11-eleven.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_11_eleven : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/12-week12.aspx.cs
+++ b/thepool/2019/12-week12.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_12_week12 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/13-13thweek.aspx.cs
+++ b/thepool/2019/13-13thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_13_13thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/14-week14.aspx.cs
+++ b/thepool/2019/14-week14.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_14_week14 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/15-fifteen.aspx.cs
+++ b/thepool/2019/15-fifteen.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_15_fifteen : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/16-wk16.aspx.cs
+++ b/thepool/2019/16-wk16.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2019_16_wk16 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2019/17-wk17of2019.aspx.cs
+++ b/thepool/2019/17-wk17of2019.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2019_17_wk17of2019 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/00-infocheck.aspx.cs
+++ b/thepool/2020/00-infocheck.aspx.cs
@@ -86,7 +86,7 @@ public partial class _2020_00_infocheck : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("f20d8c28-82a4-4740-bbbb-8e66ae", "MYSPORTSFEEDS") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk);

--- a/thepool/2020/01-week1-2020.aspx.cs
+++ b/thepool/2020/01-week1-2020.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_01_week1_2020 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/02-wk2.aspx.cs
+++ b/thepool/2020/02-wk2.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_02_wk2 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/03-week3.aspx.cs
+++ b/thepool/2020/03-week3.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_03_week3 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/04-4thweek.aspx.cs
+++ b/thepool/2020/04-4thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_04_4thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/05-5wk.aspx.cs
+++ b/thepool/2020/05-5wk.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_05_5wk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk);

--- a/thepool/2020/06-6thweek.aspx.cs
+++ b/thepool/2020/06-6thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_06_6thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/07-7week.aspx.cs
+++ b/thepool/2020/07-7week.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_07_7week : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/08-8thwk.aspx.cs
+++ b/thepool/2020/08-8thwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_08_8thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/09-week9.aspx.cs
+++ b/thepool/2020/09-week9.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_09_week9 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/10-10thweek.aspx.cs
+++ b/thepool/2020/10-10thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_10_10thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/11-eleventhwk.aspx.cs
+++ b/thepool/2020/11-eleventhwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_11_eleventhwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/12-covid.aspx.cs
+++ b/thepool/2020/12-covid.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_12_covid : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/12-thanksgiving.aspx.cs
+++ b/thepool/2020/12-thanksgiving.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_12_thanksgiving : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/13-13thweek.aspx.cs
+++ b/thepool/2020/13-13thweek.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_13_13thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/14-wk14.aspx.cs
+++ b/thepool/2020/14-wk14.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2020_14_wk14 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/15-week15.aspx.cs
+++ b/thepool/2020/15-week15.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_15_week15 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/16-christmas.aspx.cs
+++ b/thepool/2020/16-christmas.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_16_christmas : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2020/17-2020wk17.aspx.cs
+++ b/thepool/2020/17-2020wk17.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2020_17_2020wk17 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/00-infocheck.aspx.cs
+++ b/thepool/2021/00-infocheck.aspx.cs
@@ -86,7 +86,7 @@ public partial class _2020_00_infocheck : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("f20d8c28-82a4-4740-bbbb-8e66ae", "MYSPORTSFEEDS") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk);

--- a/thepool/2021/01-wk1-2021.aspx.cs
+++ b/thepool/2021/01-wk1-2021.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_01_wk1_2021 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/02-secondweek.aspx.cs
+++ b/thepool/2021/02-secondweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_02_secondweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/03-3rd-week.aspx.cs
+++ b/thepool/2021/03-3rd-week.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_03_3rd_week : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/04-the4thwk.aspx.cs
+++ b/thepool/2021/04-the4thwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_04_the4thwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/05-fifthweek21.aspx.cs
+++ b/thepool/2021/05-fifthweek21.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_05_fifthweek21 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/06-weeksix.aspx.cs
+++ b/thepool/2021/06-weeksix.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_06_weeksix : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/07-7thweek.aspx.cs
+++ b/thepool/2021/07-7thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_07_7thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/08-wk8.aspx.cs
+++ b/thepool/2021/08-wk8.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_08_wk8 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/09-ninthwk.aspx.cs
+++ b/thepool/2021/09-ninthwk.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_09_ninthwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/10-week10.aspx.cs
+++ b/thepool/2021/10-week10.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_10_week10 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/11-11thweek.aspx.cs
+++ b/thepool/2021/11-11thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_11_11thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/12-thxgiv.aspx.cs
+++ b/thepool/2021/12-thxgiv.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_12_thxgiv : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/13-13thweek.aspx.cs
+++ b/thepool/2021/13-13thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_13_13thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/14-wk14.aspx.cs
+++ b/thepool/2021/14-wk14.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2021_14_wk14 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/15-weekbeforexmas.aspx.cs
+++ b/thepool/2021/15-weekbeforexmas.aspx.cs
@@ -90,7 +90,7 @@ public partial class _2021_15_weekbeforexmas : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/16-xmas.aspx.cs
+++ b/thepool/2021/16-xmas.aspx.cs
@@ -90,7 +90,7 @@ public partial class _2021_16_xmas : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/17-newyear.aspx.cs
+++ b/thepool/2021/17-newyear.aspx.cs
@@ -90,7 +90,7 @@ public partial class _2021_17_newyear : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2021/18-18thwk2021.aspx.cs
+++ b/thepool/2021/18-18thwk2021.aspx.cs
@@ -90,7 +90,7 @@ public partial class _2021_18_18thwk2021 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/00-infocheck.aspx.cs
+++ b/thepool/2023/00-infocheck.aspx.cs
@@ -86,7 +86,7 @@ public partial class _2020_00_infocheck : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("f20d8c28-82a4-4740-bbbb-8e66ae", "MYSPORTSFEEDS") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk);

--- a/thepool/2023/01-2023-wk1.aspx.cs
+++ b/thepool/2023/01-2023-wk1.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_01_2023_wk1 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/02-secondwk23.aspx.cs
+++ b/thepool/2023/02-secondwk23.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_02_secondwk23 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/03-week3.aspx.cs
+++ b/thepool/2023/03-week3.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_03_week3 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/04-4thweek23.aspx.cs
+++ b/thepool/2023/04-4thweek23.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_04_4thweek23 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/05-byeweek1.aspx.cs
+++ b/thepool/2023/05-byeweek1.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_05_byeweek1 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/06-6thwk23.aspx.cs
+++ b/thepool/2023/06-6thwk23.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_06_6thwk23 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/07-week7.aspx.cs
+++ b/thepool/2023/07-week7.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_07_week7 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/08-8thweek.aspx.cs
+++ b/thepool/2023/08-8thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_08_8thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/09-ninth2023.aspx.cs
+++ b/thepool/2023/09-ninth2023.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_09_ninth2023 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/10-the10thweek.aspx.cs
+++ b/thepool/2023/10-the10thweek.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_10_the10thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/11-eleven.aspx.cs
+++ b/thepool/2023/11-eleven.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_11_eleven : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/12-thanksgiving23.aspx.cs
+++ b/thepool/2023/12-thanksgiving23.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2023_12_thanksgiving23 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/13-week13.aspx.cs
+++ b/thepool/2023/13-week13.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_13_week13 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/14-fourteen.aspx.cs
+++ b/thepool/2023/14-fourteen.aspx.cs
@@ -84,7 +84,7 @@ public partial class _2023_14_fourteen : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/15-fifteenthwk.aspx.cs
+++ b/thepool/2023/15-fifteenthwk.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2023_15_fifteenthwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/16-the16thweek.aspx.cs
+++ b/thepool/2023/16-the16thweek.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2023_16_the16thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/17-wk17.aspx.cs
+++ b/thepool/2023/17-wk17.aspx.cs
@@ -87,7 +87,7 @@ public partial class _2023_17_wk17 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);

--- a/thepool/2023/18-the18thweek.aspx.cs
+++ b/thepool/2023/18-the18thweek.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2023_18_the18thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2023_18_the18thweek : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         // numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/01-firstwk24.aspx.cs
+++ b/thepool/2024/01-firstwk24.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_01_firstwk24 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_01_firstwk24 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/02-weektwo.aspx.cs
+++ b/thepool/2024/02-weektwo.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_02_weektwo : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_02_weektwo : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/03-3rdweek.aspx.cs
+++ b/thepool/2024/03-3rdweek.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_03_3rdweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_03_3rdweek : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/04-week4.aspx.cs
+++ b/thepool/2024/04-week4.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_04_week4 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_04_week4 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/05-5thwk24.aspx.cs
+++ b/thepool/2024/05-5thwk24.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_05_5thwk24 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_05_5thwk24 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/06-wk6.aspx.cs
+++ b/thepool/2024/06-wk6.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_06_wk6 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_06_wk6 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/07-seventhwk.aspx.cs
+++ b/thepool/2024/07-seventhwk.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_07_seventhwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_07_seventhwk : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/08-halloween.aspx.cs
+++ b/thepool/2024/08-halloween.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_08_halloween : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_08_halloween : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/09-weeknine24.aspx.cs
+++ b/thepool/2024/09-weeknine24.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_09_weeknine24 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_09_weeknine24 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/10-tenth.aspx.cs
+++ b/thepool/2024/10-tenth.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_10_tenth : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_10_tenth : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/11-eleventhwk.aspx.cs
+++ b/thepool/2024/11-eleventhwk.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_11_eleventhwk : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_11_eleventhwk : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/12-the12thweek.aspx.cs
+++ b/thepool/2024/12-the12thweek.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_12_the12thweek : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_12_the12thweek : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/13-tgiving24.aspx.cs
+++ b/thepool/2024/13-tgiving24.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_13_tgiving24 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_13_tgiving24 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/14-week14.aspx.cs
+++ b/thepool/2024/14-week14.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_14_week14 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_14_week14 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/15-fifteenth24.aspx.cs
+++ b/thepool/2024/15-fifteenth24.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_15_fifteenth24 : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_15_fifteenth24 : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/16-week16th.aspx.cs
+++ b/thepool/2024/16-week16th.aspx.cs
@@ -88,7 +88,7 @@ public partial class _2024_16_week16th : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -116,8 +116,8 @@ public partial class _2024_16_week16th : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/17-10gamescount.aspx.cs
+++ b/thepool/2024/17-10gamescount.aspx.cs
@@ -91,7 +91,7 @@ public partial class _2024_17_10gamescount : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -122,8 +122,8 @@ public partial class _2024_17_10gamescount : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/2024/18-happynewyear.aspx.cs
+++ b/thepool/2024/18-happynewyear.aspx.cs
@@ -91,7 +91,7 @@ public partial class _2024_18_happynewyear : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -122,8 +122,8 @@ public partial class _2024_18_happynewyear : System.Web.UI.Page
         numberofgamescores2 = livescores2.scoreboard.gameScore.Length;
         //numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);

--- a/thepool/App_Code/CredentialStore.cs
+++ b/thepool/App_Code/CredentialStore.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Configuration;
+using System.Net;
+
+public static class CredentialStore
+{
+        public static string ApiUsername =>
+            Environment.GetEnvironmentVariable("POOL_API_USERNAME") ??
+            ConfigurationManager.AppSettings["ApiUsername"];
+
+        public static string ApiPassword =>
+            Environment.GetEnvironmentVariable("POOL_API_PASSWORD") ??
+            ConfigurationManager.AppSettings["ApiPassword"];
+
+        public static string DbUser =>
+            Environment.GetEnvironmentVariable("POOL_DB_USER") ??
+            ConfigurationManager.AppSettings["DbUser"];
+
+        public static string DbPassword =>
+            Environment.GetEnvironmentVariable("POOL_DB_PASSWORD") ??
+            ConfigurationManager.AppSettings["DbPassword"];
+
+        public static string EmailAddress =>
+            Environment.GetEnvironmentVariable("POOL_EMAIL_ADDRESS") ??
+            ConfigurationManager.AppSettings["EmailAddress"];
+
+        public static string EmailPassword =>
+            Environment.GetEnvironmentVariable("POOL_EMAIL_PASSWORD") ??
+            ConfigurationManager.AppSettings["EmailPassword"];
+
+        public static NetworkCredential ApiCredential =>
+            new NetworkCredential(ApiUsername, ApiPassword);
+
+        public static NetworkCredential EmailCredential =>
+            new NetworkCredential(EmailAddress, EmailPassword);
+
+        public static string ScoresConnectionString =>
+            $"Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID={DbUser};Password={DbPassword};";
+
+        public static string PoolConnectionString =>
+            $"Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID={DbUser};Password={DbPassword};";
+}

--- a/thepool/Default.aspx.cs
+++ b/thepool/Default.aspx.cs
@@ -90,7 +90,7 @@ public partial class _Default : System.Web.UI.Page
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         // Use SecurityProtocolType.Ssl3 if needed for compatibility reasons
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
         
         var response = client.DownloadString(urlwk1);
         // var responselastyear = client.DownloadString(urlts);
@@ -111,7 +111,7 @@ public partial class _Default : System.Web.UI.Page
 
 
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
         // Establishing MySQL connection
         MySqlConnection connection = new MySqlConnection(connectionString);
@@ -285,7 +285,7 @@ public partial class _Default : System.Web.UI.Page
 
         
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.PoolConnectionString;
 
         MySqlConnection connection = new MySqlConnection(connectionString);
 
@@ -343,7 +343,7 @@ public partial class _Default : System.Web.UI.Page
     protected void SendMail()
     {
         // Gmail Address from where you send the mail
-        var fromAddress = "pool@bellfootball.com";
+        var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
         var ccAddress = ",jab73@me.com";
@@ -352,7 +352,7 @@ public partial class _Default : System.Web.UI.Page
 
 
         //Password of your gmail address
-        const string fromPassword = "1998PlayBFP$";
+        var fromPassword = CredentialStore.EmailPassword;
         // Passing the values and make a email formate to display
         string subject = "Week 18 - 2024 Football Picks";
         string body = firstnameText + " " + lastnameText +" picks for week 18: \n\n";
@@ -385,7 +385,7 @@ public partial class _Default : System.Web.UI.Page
         string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
-        credentialCache.Add(new System.Uri(url), "Basic", new NetworkCredential(ConfigurationManager.AppSettings["bbd5a2c0-db08-41fb-be02-305d0a"], ConfigurationManager.AppSettings["1998PlaySF$"]));
+        credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);
         return credentialCache;
     }
 

--- a/thepool/Web.config
+++ b/thepool/Web.config
@@ -4,6 +4,14 @@
   https://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
+  <appSettings>
+    <add key="ApiUsername" value="REPLACE_WITH_API_USERNAME" />
+    <add key="ApiPassword" value="REPLACE_WITH_API_PASSWORD" />
+    <add key="DbUser" value="REPLACE_WITH_DB_USERNAME" />
+    <add key="DbPassword" value="REPLACE_WITH_DB_PASSWORD" />
+    <add key="EmailAddress" value="pool@example.com" />
+    <add key="EmailPassword" value="REPLACE_WITH_EMAIL_PASSWORD" />
+  </appSettings>
   <system.web>
     <compilation targetFramework="4.5.2" debug="true">
       <assemblies>

--- a/thepool/add-picks.aspx.cs
+++ b/thepool/add-picks.aspx.cs
@@ -84,7 +84,7 @@ public partial class add_picks : System.Web.UI.Page
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         // Use SecurityProtocolType.Ssl3 if needed for compatibility reasons
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
         var response = client.DownloadString(urlwk1);
         // var responselastyear = client.DownloadString(urlts);
@@ -105,7 +105,7 @@ public partial class add_picks : System.Web.UI.Page
 
 
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
         // Establishing MySQL connection
         MySqlConnection connection = new MySqlConnection(connectionString);
@@ -279,7 +279,7 @@ public partial class add_picks : System.Web.UI.Page
 
 
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.PoolConnectionString;
 
         MySqlConnection connection = new MySqlConnection(connectionString);
 
@@ -337,7 +337,7 @@ public partial class add_picks : System.Web.UI.Page
     protected void SendMail()
     {
         // Gmail Address from where you send the mail
-        var fromAddress = "pool@bellfootball.com";
+        var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
         var ccAddress = ",jab73@me.com";
@@ -346,7 +346,7 @@ public partial class add_picks : System.Web.UI.Page
 
 
         //Password of your gmail address
-        const string fromPassword = "1998PlayBFP$";
+        var fromPassword = CredentialStore.EmailPassword;
         // Passing the values and make a email formate to display
         string subject = "Week 1 - 2024 Football Picks";
         string body = firstnameText + " " + lastnameText + " picks for week 1: \n\n";
@@ -379,7 +379,7 @@ public partial class add_picks : System.Web.UI.Page
         string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241010-to-20241014";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
-        credentialCache.Add(new System.Uri(url), "Basic", new NetworkCredential(ConfigurationManager.AppSettings["bbd5a2c0-db08-41fb-be02-305d0a"], ConfigurationManager.AppSettings["1998PlaySF$"]));
+        credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);
         return credentialCache;
     }
 

--- a/thepool/scoreboard/2000.aspx.cs
+++ b/thepool/scoreboard/2000.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2000 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2001.aspx.cs
+++ b/thepool/scoreboard/2001.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2001 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2002.aspx.cs
+++ b/thepool/scoreboard/2002.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2002 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2003.aspx.cs
+++ b/thepool/scoreboard/2003.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2003 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2004.aspx.cs
+++ b/thepool/scoreboard/2004.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2004 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2005.aspx.cs
+++ b/thepool/scoreboard/2005.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2005 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2006.aspx.cs
+++ b/thepool/scoreboard/2006.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2006 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2007.aspx.cs
+++ b/thepool/scoreboard/2007.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2007 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2008.aspx.cs
+++ b/thepool/scoreboard/2008.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2008 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2009.aspx.cs
+++ b/thepool/scoreboard/2009.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2009 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2010.aspx.cs
+++ b/thepool/scoreboard/2010.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2010 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2011.aspx.cs
+++ b/thepool/scoreboard/2011.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2011 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2012.aspx.cs
+++ b/thepool/scoreboard/2012.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2012 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2013.aspx.cs
+++ b/thepool/scoreboard/2013.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2013 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2014.aspx.cs
+++ b/thepool/scoreboard/2014.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2014 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2015.aspx.cs
+++ b/thepool/scoreboard/2015.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2015 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2016.aspx.cs
+++ b/thepool/scoreboard/2016.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2016 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2017.aspx.cs
+++ b/thepool/scoreboard/2017.aspx.cs
@@ -47,7 +47,7 @@ public partial class scoreboard_2017 : System.Web.UI.Page
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2018.aspx.cs
+++ b/thepool/scoreboard/2018.aspx.cs
@@ -46,7 +46,7 @@ public partial class scoreboard_2018 : System.Web.UI.Page
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2019.aspx.cs
+++ b/thepool/scoreboard/2019.aspx.cs
@@ -46,7 +46,7 @@ public partial class scoreboard_2019 : System.Web.UI.Page
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2020.aspx.cs
+++ b/thepool/scoreboard/2020.aspx.cs
@@ -46,7 +46,7 @@ public partial class scoreboard_2020 : System.Web.UI.Page
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2021.aspx.cs
+++ b/thepool/scoreboard/2021.aspx.cs
@@ -47,7 +47,7 @@ public partial class scoreboard_2021 : System.Web.UI.Page
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2023.aspx.cs
+++ b/thepool/scoreboard/2023.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2023 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/2024.aspx.cs
+++ b/thepool/scoreboard/2024.aspx.cs
@@ -48,7 +48,7 @@ public partial class scoreboard_2024 : System.Web.UI.Page
     protected void Page_Load(object sender, EventArgs e)
     {
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
 
         // First connection (for scores.mdb equivalent)

--- a/thepool/scoreboard/scoresInsert.aspx.cs
+++ b/thepool/scoreboard/scoresInsert.aspx.cs
@@ -94,7 +94,7 @@ public partial class scoreboard_scoresInsert : System.Web.UI.Page
         ServicePointManager.Expect100Continue = true;
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-        var client = new WebClient { Credentials = new NetworkCredential("bbd5a2c0-xxxx-xxxx-xxxx-305d0a", "My69Password") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
 
 
         var response = client.DownloadString(urlwk2);
@@ -126,8 +126,8 @@ public partial class scoreboard_scoresInsert : System.Web.UI.Page
         numberofgamescores3 = livescores3.scoreboard.gameScore.Length;
 
 
-        //string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
-        string connectionString2 = "Server=mysql24.ezhostingserver.com;Database=bfpoolDB;User ID=MyName69;Password=ThePassword69;";
+        //string connectionString = CredentialStore.ScoresConnectionString;
+        string connectionString2 = CredentialStore.PoolConnectionString;
 
         // First connection (for scores.mdb equivalent)
         /* MySqlConnection connection = new MySqlConnection(connectionString);
@@ -432,7 +432,7 @@ public partial class scoreboard_scoresInsert : System.Web.UI.Page
 
     public int AllTotals(string theFirst, string theLast)
     {
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
 
         MySqlConnection connection = new MySqlConnection(connectionString);
         connection.Open();
@@ -463,7 +463,7 @@ public partial class scoreboard_scoresInsert : System.Web.UI.Page
         int totalEntries;
         Int32.TryParse(Request.Form["totalEntries"].ToString(), out totalEntries);
 
-        string connectionString = "Server=mysql24.ezhostingserver.com;Database=bfscoresDB;User ID=MyName69;Password=ThePassword69;";
+        string connectionString = CredentialStore.ScoresConnectionString;
         MySqlConnection connection = new MySqlConnection(connectionString);
 
         try

--- a/thepool/thepool/Default.aspx.cs
+++ b/thepool/thepool/Default.aspx.cs
@@ -89,7 +89,7 @@ public partial class _Default : System.Web.UI.Page
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         // Use SecurityProtocolType.Ssl3 if needed for compatibility reasons
 
-        var client = new WebClient { Credentials = new NetworkCredential("shocktor", "1998PlaySF$") };
+        var client = new WebClient { Credentials = CredentialStore.ApiCredential };
         
         var response = client.DownloadString(urlwk1);
         var responselastyear = client.DownloadString(urlts);
@@ -274,7 +274,7 @@ public partial class _Default : System.Web.UI.Page
     protected void SendMail()
     {
         // Gmail Address from where you send the mail
-        var fromAddress = "pool@bellfusion.com";
+        var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
         var ccAddress = ",jab73@me.com";
@@ -283,7 +283,7 @@ public partial class _Default : System.Web.UI.Page
 
 
         //Password of your gmail address
-        const string fromPassword = "1998PlayPOOL$";
+        var fromPassword = CredentialStore.EmailPassword;
         // Passing the values and make a email formate to display
         string subject = "Week 10 Football Picks";
         string body = "Your picks for week 10: \n\n";
@@ -316,7 +316,7 @@ public partial class _Default : System.Web.UI.Page
         string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
-        credentialCache.Add(new System.Uri(url), "Basic", new NetworkCredential(ConfigurationManager.AppSettings["shocktor"], ConfigurationManager.AppSettings["1998PlaySF$"]));
+        credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);
         return credentialCache;
     }
 


### PR DESCRIPTION
## Summary
- add `CredentialStore` helper that loads API, database, and email credentials from environment variables or web.config
- replace all hard-coded usernames, passwords, and connection strings across pages with calls to `CredentialStore`
- define placeholder keys in `Web.config` for credentials

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b9a662a08331975de2d69b5b933f