### PR TITLE
Centralize cc email addresses to config

### DIFF
--- a/thepool/App_Code/CredentialStore.cs
+++ b/thepool/App_Code/CredentialStore.cs
@@ -28,6 +28,10 @@ public static class CredentialStore
             Environment.GetEnvironmentVariable("POOL_EMAIL_PASSWORD") ??
             ConfigurationManager.AppSettings["EmailPassword"];
 
+        public static string CcAddress =>
+            Environment.GetEnvironmentVariable("POOL_CC_ADDRESS") ??
+            ConfigurationManager.AppSettings["CcAddress"];
+
         public static NetworkCredential ApiCredential =>
             new NetworkCredential(ApiUsername, ApiPassword);
 

--- a/thepool/Default.aspx.cs
+++ b/thepool/Default.aspx.cs
@@ -346,8 +346,8 @@ public partial class _Default : System.Web.UI.Page
         var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
-        var ccAddress = ",jab73@me.com";
-        toAddress += ccAddress;
+        var ccAddress = CredentialStore.CcAddress;
+        toAddress += "," + ccAddress;
 
 
 

--- a/thepool/Web.config.example
+++ b/thepool/Web.config.example
@@ -11,6 +11,7 @@
     <add key="DbPassword" value="REPLACE_WITH_DB_PASSWORD" />
     <add key="EmailAddress" value="pool@example.com" />
     <add key="EmailPassword" value="REPLACE_WITH_EMAIL_PASSWORD" />
+    <add key="CcAddress" value="cc@example.com" />
   </appSettings>
   <system.web>
     <compilation targetFramework="4.5.2" debug="true">

--- a/thepool/add-picks.aspx.cs
+++ b/thepool/add-picks.aspx.cs
@@ -340,8 +340,8 @@ public partial class add_picks : System.Web.UI.Page
         var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
-        var ccAddress = ",jab73@me.com";
-        toAddress += ccAddress;
+        var ccAddress = CredentialStore.CcAddress;
+        toAddress += "," + ccAddress;
 
 
 

--- a/thepool/thepool/Default.aspx.cs
+++ b/thepool/thepool/Default.aspx.cs
@@ -277,8 +277,8 @@ public partial class _Default : System.Web.UI.Page
         var fromAddress = CredentialStore.EmailAddress;
         // any address where the email will be sending
         var toAddress = emailText;
-        var ccAddress = ",jab73@me.com";
-        toAddress += ccAddress;
+        var ccAddress = CredentialStore.CcAddress;
+        toAddress += "," + ccAddress;
 
 
 


### PR DESCRIPTION
## Summary
- Add CcAddress property using environment variable or Web.config
- Use CredentialStore.CcAddress in all mail-sending pages to remove hardcoded addresses
- Include CcAddress placeholder in Web.config.example

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb03ecd19483319061a64cd75a5097