### PR TITLE
Centralize web addresses

### DIFF
--- a/thepool/App_Code/CredentialStore.cs
+++ b/thepool/App_Code/CredentialStore.cs
@@ -32,6 +32,18 @@ public static class CredentialStore
             Environment.GetEnvironmentVariable("POOL_CC_ADDRESS") ??
             ConfigurationManager.AppSettings["CcAddress"];
 
+        public static string BaseUrl =>
+            Environment.GetEnvironmentVariable("POOL_BASE_URL") ??
+            ConfigurationManager.AppSettings["BaseUrl"];
+
+        public static string ApiBaseUrl =>
+            Environment.GetEnvironmentVariable("POOL_API_BASE_URL") ??
+            ConfigurationManager.AppSettings["ApiBaseUrl"];
+
+        public static string SmtpHost =>
+            Environment.GetEnvironmentVariable("POOL_SMTP_HOST") ??
+            ConfigurationManager.AppSettings["SmtpHost"];
+
         public static NetworkCredential ApiCredential =>
             new NetworkCredential(ApiUsername, ApiPassword);
 

--- a/thepool/Default.aspx.cs
+++ b/thepool/Default.aspx.cs
@@ -22,7 +22,7 @@ using MySql.Data.MySqlClient;
 
 public partial class _Default : System.Web.UI.Page
 {
-    public string urlwk1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
+    public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
     // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-2021-regular/overall_team_standings.json";
 
     public int numberofgames;
@@ -363,13 +363,13 @@ public partial class _Default : System.Web.UI.Page
         {
             body += showall.fullgameschedule.gameentry[i].awayTeam.Abbreviation + " vs. " + showall.fullgameschedule.gameentry[i].homeTeam.Abbreviation + ": " + gamePicksArray[i] + "\n";
         }
-        body += "\n Picks Link: http://www.bellfootball.com/football/thepool/2024/18-happynewyear.aspx \n";
+        body += $"\n Picks Link: {CredentialStore.BaseUrl}/football/thepool/2024/18-happynewyear.aspx \n";
         // body += "Subject: " + YourSubject.Text + "\n";
         // body += "Question: \n" + Comments.Text + "\n";
         // smtp settings
         var smtp = new System.Net.Mail.SmtpClient();
         {
-            smtp.Host = "mail16.ezhostingserver.com";
+            smtp.Host = CredentialStore.SmtpHost;
             smtp.Port = 587;
             smtp.DeliveryMethod = System.Net.Mail.SmtpDeliveryMethod.Network;
             smtp.Credentials = new NetworkCredential(fromAddress, fromPassword);
@@ -382,7 +382,7 @@ public partial class _Default : System.Web.UI.Page
 
     private CredentialCache GetCredential()
     {
-        string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
+        string url = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
         credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);

--- a/thepool/Web.config.example
+++ b/thepool/Web.config.example
@@ -12,6 +12,9 @@
     <add key="EmailAddress" value="pool@example.com" />
     <add key="EmailPassword" value="REPLACE_WITH_EMAIL_PASSWORD" />
     <add key="CcAddress" value="cc@example.com" />
+    <add key="BaseUrl" value="http://www.bellfootball.com" />
+    <add key="ApiBaseUrl" value="https://api.mysportsfeeds.com/v1.1/pull/nfl" />
+    <add key="SmtpHost" value="mail16.ezhostingserver.com" />
   </appSettings>
   <system.web>
     <compilation targetFramework="4.5.2" debug="true">

--- a/thepool/add-picks.aspx.cs
+++ b/thepool/add-picks.aspx.cs
@@ -16,7 +16,7 @@ using MySql.Data.MySqlClient;
 
 public partial class add_picks : System.Web.UI.Page
 {
-    public string urlwk1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241003-to-20241007";
+    public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241003-to-20241007";
     // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-2021-regular/overall_team_standings.json";
 
     public int numberofgames;
@@ -357,13 +357,13 @@ public partial class add_picks : System.Web.UI.Page
         {
             body += showall.fullgameschedule.gameentry[i].awayTeam.Abbreviation + " vs. " + showall.fullgameschedule.gameentry[i].homeTeam.Abbreviation + ": " + gamePicksArray[i] + "\n";
         }
-        body += "\n Picks Link: http://www.bellfootball.com/football/thepool/2024/06-wk6.aspx \n";
+        body += $"\n Picks Link: {CredentialStore.BaseUrl}/football/thepool/2024/06-wk6.aspx \n";
         // body += "Subject: " + YourSubject.Text + "\n";
         // body += "Question: \n" + Comments.Text + "\n";
         // smtp settings
         var smtp = new System.Net.Mail.SmtpClient();
         {
-            smtp.Host = "mail16.ezhostingserver.com";
+            smtp.Host = CredentialStore.SmtpHost;
             smtp.Port = 587;
             smtp.DeliveryMethod = System.Net.Mail.SmtpDeliveryMethod.Network;
             smtp.Credentials = new NetworkCredential(fromAddress, fromPassword);
@@ -376,7 +376,7 @@ public partial class add_picks : System.Web.UI.Page
 
     private CredentialCache GetCredential()
     {
-        string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241010-to-20241014";
+        string url = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241010-to-20241014";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
         credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);


### PR DESCRIPTION
## Summary
- centralize site and API URLs alongside SMTP host in configuration helper
- replace hard-coded addresses in pick submission pages with config-driven values
- expose new configuration keys for base URL, API endpoint base, and mail host

## Testing
- `msbuild website.publishproj` *(fails: command not found)*
- `dotnet build website.publishproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bb5d7c08331915cfd9bcf05ee61