### PR TITLE
Centralize sports feeds API URLs

### DIFF
--- a/thepool/2017/01-weekone.aspx.cs
+++ b/thepool/2017/01-weekone.aspx.cs
@@ -18,12 +18,12 @@ using System.Collections.Specialized;
 public partial class _2017_01_weekone : System.Web.UI.Page
 {
 
-    public string urlwk1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170907";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170910";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170911";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170907";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170910";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170911";
 
 
     public int numberofgames;

--- a/thepool/2017/02-secondweek.aspx.cs
+++ b/thepool/2017/02-secondweek.aspx.cs
@@ -18,12 +18,12 @@ using System.Collections.Specialized;
 public partial class _2017_02_secondweek : System.Web.UI.Page
 {
 
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170914-to-20170918";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170914-to-20170918";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170914";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170917";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170918";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170914";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170917";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170918";
 
 
     public int numberofgames;

--- a/thepool/2017/03-thirdwk.aspx.cs
+++ b/thepool/2017/03-thirdwk.aspx.cs
@@ -17,12 +17,12 @@ using System.Collections.Specialized;
 public partial class _2017_03_thirdwk : System.Web.UI.Page
 {
 
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170921-to-20170925";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170921-to-20170925";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170921";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170924";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170925";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170921";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170924";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170925";
 
 
     public int numberofgames;

--- a/thepool/2017/04-4thwk.aspx.cs
+++ b/thepool/2017/04-4thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_04_4thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170928-to-20171002";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170928-to-20171002";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20170928";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171001";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171002";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20170928";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171001";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171002";
 
 
     public int numberofgames;

--- a/thepool/2017/05-week5.aspx.cs
+++ b/thepool/2017/05-week5.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_05_week5 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171005-to-20171009";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171005-to-20171009";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171005";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171008";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171009";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171005";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171008";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171009";
 
 
     public int numberofgames;

--- a/thepool/2017/06-6thweek.aspx.cs
+++ b/thepool/2017/06-6thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_06_6thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171012-to-20171016";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171012-to-20171016";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171012";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171015";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171016";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171012";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171015";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171016";
 
 
     public int numberofgames;

--- a/thepool/2017/07-seven.aspx.cs
+++ b/thepool/2017/07-seven.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_07_seven : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171019-to-20171023";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171019-to-20171023";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171019";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171022";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171023";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171019";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171022";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171023";
 
 
     public int numberofgames;

--- a/thepool/2017/08-8thweek.aspx.cs
+++ b/thepool/2017/08-8thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_08_8thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171026-to-20171030";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171026-to-20171030";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171026";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171029";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171030";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171026";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171029";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171030";
 
 
     public int numberofgames;

--- a/thepool/2017/09-9thwk.aspx.cs
+++ b/thepool/2017/09-9thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_09_9thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171102-to-20171106";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171102-to-20171106";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171102";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171105";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171106";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171102";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171105";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171106";
 
 
     public int numberofgames;

--- a/thepool/2017/10-tenthwk.aspx.cs
+++ b/thepool/2017/10-tenthwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_10_tenthwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171109";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171112";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171113";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171109";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171112";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171113";
 
 
     public int numberofgames;

--- a/thepool/2017/11-eleven.aspx.cs
+++ b/thepool/2017/11-eleven.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class thepool_2017_11_eleven : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171116-to-20171120";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171116-to-20171120";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171116";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171119";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171120";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171116";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171119";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171120";
 
 
     public int numberofgames;

--- a/thepool/2017/12-thanksgivingweek.aspx.cs
+++ b/thepool/2017/12-thanksgivingweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_12_thanksgivingweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171123-to-20171127";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171123-to-20171127";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171123";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171126";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171127";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171123";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171126";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171127";
 
 
     public int numberofgames;

--- a/thepool/2017/13-wk13.aspx.cs
+++ b/thepool/2017/13-wk13.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_13_wk13 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171130-to-20171204";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171130-to-20171204";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171130";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171203";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171204";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171130";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171203";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171204";
 
 
     public int numberofgames;

--- a/thepool/2017/14-weekfourteen.aspx.cs
+++ b/thepool/2017/14-weekfourteen.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2017_14_weekfourteen : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171207-to-20171211";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171207-to-20171211";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171207";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171210";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171211";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171207";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171210";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171211";
 
 
     public int numberofgames;

--- a/thepool/2017/15-week15.aspx.cs
+++ b/thepool/2017/15-week15.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2017_15_week15 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171214-to-20171218";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171214-to-20171218";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171214";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171216";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171217";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171218";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171214";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171216";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171217";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171218";
 
 
     public int numberofgames;

--- a/thepool/2017/16-sweet16.aspx.cs
+++ b/thepool/2017/16-sweet16.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2017_16_sweet16 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171223-to-20171225";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171223-to-20171225";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    // public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171214";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171223";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171224";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171225";
+    // public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171214";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171223";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171224";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171225";
 
 
     public int numberofgames;

--- a/thepool/2017/17-17thweek17.aspx.cs
+++ b/thepool/2017/17-17thweek17.aspx.cs
@@ -16,11 +16,11 @@ using System.Collections.Specialized;
 
 public partial class _2017_17_17thweek17 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171231-to-20171231";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171231-to-20171231";
     
 
     
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/scoreboard.json?fordate=20171231";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2017-regular/scoreboard.json?fordate=20171231";
     
 
 

--- a/thepool/2018/01-week1-18.aspx.cs
+++ b/thepool/2018/01-week1-18.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_01_week1_18 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20180906-to-20180910";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20180906-to-20180910";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180909";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180910";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180909";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180910";
 
 
     public int numberofgames;

--- a/thepool/2018/02-weektwo.aspx.cs
+++ b/thepool/2018/02-weektwo.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_02_weektwo : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20180913-to-20180917";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20180913-to-20180917";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180913";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180916";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180917";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180913";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180916";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180917";
 
 
     public int numberofgames;

--- a/thepool/2018/03-3rdweek.aspx.cs
+++ b/thepool/2018/03-3rdweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_03_3rdweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20180920-to-20180924";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20180920-to-20180924";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180920";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180923";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180924";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180920";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180923";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180924";
 
 
     public int numberofgames;

--- a/thepool/2018/04-4thwk.aspx.cs
+++ b/thepool/2018/04-4thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_04_4thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20180927-to-20181001";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20180927-to-20181001";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180927";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20180930";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181001";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180927";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20180930";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181001";
 
 
     public int numberofgames;

--- a/thepool/2018/05-5thweek5.aspx.cs
+++ b/thepool/2018/05-5thweek5.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_05_5thweek5 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181004-to-20181008";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181004-to-20181008";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181004";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181007";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181008";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181004";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181007";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181008";
 
 
     public int numberofgames;

--- a/thepool/2018/06-6th-week.aspx.cs
+++ b/thepool/2018/06-6th-week.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_06_6th_week : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181011-to-20181015";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181011-to-20181015";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181011";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181014";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181015";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181011";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181014";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181015";
 
 
     public int numberofgames;

--- a/thepool/2018/07-7seventhweek.aspx.cs
+++ b/thepool/2018/07-7seventhweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_07_7seventhweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181018-to-20181022";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181018-to-20181022";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181018";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181021";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181022";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181018";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181021";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181022";
 
 
     public int numberofgames;

--- a/thepool/2018/08-8thwk.aspx.cs
+++ b/thepool/2018/08-8thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_08_8thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181025-to-20181029";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181025-to-20181029";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181025";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181028";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181029";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181025";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181028";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181029";
 
 
     public int numberofgames;

--- a/thepool/2018/09-9nine.aspx.cs
+++ b/thepool/2018/09-9nine.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_09_9nine : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181101-to-20181105";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181101-to-20181105";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181101";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181104";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181105";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181101";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181104";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181105";
 
 
     public int numberofgames;

--- a/thepool/2018/10-10thwk18.aspx.cs
+++ b/thepool/2018/10-10thwk18.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_10_10thwk18 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181108-to-20181112";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181108-to-20181112";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181108";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181111";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181112";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181108";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181111";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181112";
 
 
     public int numberofgames;

--- a/thepool/2018/11-eleven.aspx.cs
+++ b/thepool/2018/11-eleven.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_11_eleven : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181115-to-20181119";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181115-to-20181119";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181115";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181118";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181119";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181115";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181118";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181119";
 
 
     public int numberofgames;

--- a/thepool/2018/12-12thweek.aspx.cs
+++ b/thepool/2018/12-12thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_12_12thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181122-to-20181126";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181122-to-20181126";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181122";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181125";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181126";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181122";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181125";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181126";
 
 
     public int numberofgames;

--- a/thepool/2018/13-13thwk.aspx.cs
+++ b/thepool/2018/13-13thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_13_13thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181129-to-20181203";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181129-to-20181203";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181129";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181202";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181203";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181129";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181202";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181203";
 
 
     public int numberofgames;

--- a/thepool/2018/14-14thweek2018.aspx.cs
+++ b/thepool/2018/14-14thweek2018.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2018_14_14thweek2018 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181206-to-20181210";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181206-to-20181210";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181206";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181209";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181210";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181206";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181209";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181210";
 
 
     public int numberofgames;

--- a/thepool/2018/15-15th2018.aspx.cs
+++ b/thepool/2018/15-15th2018.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2018_15_15th2018 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181213-to-20181217";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181213-to-20181217";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181213";
-    public string urlscoreswk1SAT = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181215";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181216";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181217";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181213";
+    public string urlscoreswk1SAT = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181215";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181216";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181217";
 
 
     public int numberofgames;

--- a/thepool/2018/16-16thwk2018.aspx.cs
+++ b/thepool/2018/16-16thwk2018.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2018_16_16thwk2018 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181222-to-20181224";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181222-to-20181224";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181222";
-    // public string urlscoreswk1SAT = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181215";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181223";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181224";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181222";
+    // public string urlscoreswk1SAT = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181215";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181223";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181224";
 
 
     public int numberofgames;

--- a/thepool/2018/17-17thweek2018.aspx.cs
+++ b/thepool/2018/17-17thweek2018.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2018_17_17thweek2018 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181230-to-20181230";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181230-to-20181230";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    // public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181222";
-    // public string urlscoreswk1SAT = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181215";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181230";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181224";
+    // public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181222";
+    // public string urlscoreswk1SAT = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181215";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181230";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181224";
 
 
     public int numberofgames;

--- a/thepool/2018/18-TestWeek.aspx.cs
+++ b/thepool/2018/18-TestWeek.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2018_18_TestWeek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20181222-to-20181224";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20181222-to-20181224";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181222";
-    // public string urlscoreswk1SAT = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181215";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181223";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181224";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181222";
+    // public string urlscoreswk1SAT = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181215";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181223";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181224";
 
 
     public int numberofgames;

--- a/thepool/2019/01-firstwk2019.aspx.cs
+++ b/thepool/2019/01-firstwk2019.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_01_firstwk2019 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20190905-to-20190909";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20190905-to-20190909";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190905";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190908";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190909";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190905";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190908";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190909";
 
 
     public int numberofgames;

--- a/thepool/2019/02-second2019.aspx.cs
+++ b/thepool/2019/02-second2019.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_02_second2019 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20190912-to-20190916";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20190912-to-20190916";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190912";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190915";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190916";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190912";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190915";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190916";
 
 
     public int numberofgames;

--- a/thepool/2019/03-3rdwk.aspx.cs
+++ b/thepool/2019/03-3rdwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_03_3rdwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20190919-to-20190923";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20190919-to-20190923";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190919";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190922";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190923";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190919";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190922";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190923";
 
 
     public int numberofgames;

--- a/thepool/2019/04-weekfour.aspx.cs
+++ b/thepool/2019/04-weekfour.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_04_weekfour : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20190926-to-20190930";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20190926-to-20190930";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190926";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190929";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20190930";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190926";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190929";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20190930";
 
 
     public int numberofgames;

--- a/thepool/2019/05-5thweek.aspx.cs
+++ b/thepool/2019/05-5thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_05_5thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191003-to-20191007";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191003-to-20191007";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191003";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191006";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191007";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191003";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191006";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191007";
 
 
     public int numberofgames;

--- a/thepool/2019/06-wksix.aspx.cs
+++ b/thepool/2019/06-wksix.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_06_wksix : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191010-to-20191014";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191010-to-20191014";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191010";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191013";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191014";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191010";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191013";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191014";
 
 
     public int numberofgames;

--- a/thepool/2019/07-seventhwk.aspx.cs
+++ b/thepool/2019/07-seventhwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_07_seventhwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191017-to-20191021";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191017-to-20191021";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191017";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191020";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191021";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191017";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191020";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191021";
 
 
     public int numberofgames;

--- a/thepool/2019/08-weekeight.aspx.cs
+++ b/thepool/2019/08-weekeight.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_08_weekeight : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191024-to-20191028";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191024-to-20191028";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191024";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191027";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191028";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191024";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191027";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191028";
 
 
     public int numberofgames;

--- a/thepool/2019/09-09test.aspx.cs
+++ b/thepool/2019/09-09test.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_09_09test : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191031-to-20191104";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191031-to-20191104";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191031";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191103";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191104";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191031";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191103";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191104";
 
 
     public int numberofgames;

--- a/thepool/2019/09-wknine.aspx.cs
+++ b/thepool/2019/09-wknine.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_09_wknine : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191031-to-20191104";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191031-to-20191104";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191031";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191103";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191104";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191031";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191103";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191104";
 
 
     public int numberofgames;

--- a/thepool/2019/10-10thweek.aspx.cs
+++ b/thepool/2019/10-10thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_10_10thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191107-to-20191111";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191107-to-20191111";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191107";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191110";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191111";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191107";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191110";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191111";
 
 
     public int numberofgames;

--- a/thepool/2019/11-eleven.aspx.cs
+++ b/thepool/2019/11-eleven.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_11_eleven : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191114-to-20191118";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191114-to-20191118";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191114";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191117";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191118";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191114";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191117";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191118";
 
 
     public int numberofgames;

--- a/thepool/2019/12-week12.aspx.cs
+++ b/thepool/2019/12-week12.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_12_week12 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191121-to-20191125";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191121-to-20191125";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191121";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191124";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191125";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191121";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191124";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191125";
 
 
     public int numberofgames;

--- a/thepool/2019/13-13thweek.aspx.cs
+++ b/thepool/2019/13-13thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_13_13thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191128-to-20191202";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191128-to-20191202";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191128";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191201";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191202";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191128";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191201";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191202";
 
 
     public int numberofgames;

--- a/thepool/2019/14-week14.aspx.cs
+++ b/thepool/2019/14-week14.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_14_week14 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191205-to-20191209";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191205-to-20191209";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191205";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191208";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191209";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191205";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191208";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191209";
 
 
     public int numberofgames;

--- a/thepool/2019/15-fifteen.aspx.cs
+++ b/thepool/2019/15-fifteen.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_15_fifteen : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191212-to-20191216";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191212-to-20191216";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191212";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191215";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191216";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191212";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191215";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191216";
 
 
     public int numberofgames;

--- a/thepool/2019/16-wk16.aspx.cs
+++ b/thepool/2019/16-wk16.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2019_16_wk16 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191221-to-20191223";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191221-to-20191223";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191221";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191222";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191223";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191221";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191222";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191223";
 
 
     public int numberofgames;

--- a/thepool/2019/17-wk17of2019.aspx.cs
+++ b/thepool/2019/17-wk17of2019.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2019_17_wk17of2019 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/full_game_schedule.json?date=from-20191229-to-20191229";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/full_game_schedule.json?date=from-20191229-to-20191229";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    // public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181222";
-    // public string urlscoreswk1SAT = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181215";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2019-regular/scoreboard.json?fordate=20191229";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/scoreboard.json?fordate=20181224";
+    // public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181222";
+    // public string urlscoreswk1SAT = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181215";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2019-regular/scoreboard.json?fordate=20191229";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2018-regular/scoreboard.json?fordate=20181224";
 
 
     public int numberofgames;

--- a/thepool/2020/00-infocheck.aspx.cs
+++ b/thepool/2020/00-infocheck.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_00_infocheck : System.Web.UI.Page
 {
-    public string urlwk = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscores = "https://api.mysportsfeeds.com/v2.1/pull/nfl/2020-2021-regular/week/4/games.json";
-    // public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201004";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201005";
+    public string urlscores = $"{CredentialStore.ApiBaseUrlV2}/2020-2021-regular/week/4/games.json";
+    // public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201004";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201005";
 
 
     public int numberofgames;

--- a/thepool/2020/01-week1-2020.aspx.cs
+++ b/thepool/2020/01-week1-2020.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_01_week1_2020 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20200910-to-20200914";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20200910-to-20200914";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200910";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200913";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200914";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200910";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200913";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200914";
 
 
     public int numberofgames;

--- a/thepool/2020/02-wk2.aspx.cs
+++ b/thepool/2020/02-wk2.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_02_wk2 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20200917-to-20200921";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20200917-to-20200921";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200917";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200920";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200921";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200917";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200920";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200921";
 
 
     public int numberofgames;

--- a/thepool/2020/03-week3.aspx.cs
+++ b/thepool/2020/03-week3.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_03_week3 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20200924-to-20200928";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20200924-to-20200928";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200924";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200927";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200928";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200924";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200927";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200928";
 
 
     public int numberofgames;

--- a/thepool/2020/04-4thweek.aspx.cs
+++ b/thepool/2020/04-4thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_04_4thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201001";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201004";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201005";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201001";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201004";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201005";
 
 
     public int numberofgames;

--- a/thepool/2020/05-5wk.aspx.cs
+++ b/thepool/2020/05-5wk.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_05_5wk : System.Web.UI.Page
 {
-    public string urlwk = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201008-to-20201013";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201008-to-20201013";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201008";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201011";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201012";
-    public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201013";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201008";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201011";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201012";
+    public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201013";
 
 
     public int numberofgames;

--- a/thepool/2020/06-6thweek.aspx.cs
+++ b/thepool/2020/06-6thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_06_6thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201018-to-20201019";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201018-to-20201019";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    // public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20200924";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201018";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201019";
+    // public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20200924";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201018";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201019";
 
 
     public int numberofgames;

--- a/thepool/2020/07-7week.aspx.cs
+++ b/thepool/2020/07-7week.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_07_7week : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201022-to-20201026";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201022-to-20201026";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201022";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201025";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201026";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201022";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201025";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201026";
 
 
     public int numberofgames;

--- a/thepool/2020/08-8thwk.aspx.cs
+++ b/thepool/2020/08-8thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_08_8thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201029-to-20201102";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201029-to-20201102";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201029";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201101";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201102";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201029";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201101";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201102";
 
 
     public int numberofgames;

--- a/thepool/2020/09-week9.aspx.cs
+++ b/thepool/2020/09-week9.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_09_week9 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201105-to-20201109";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201105-to-20201109";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201105";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201108";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201109";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201105";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201108";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201109";
 
 
     public int numberofgames;

--- a/thepool/2020/10-10thweek.aspx.cs
+++ b/thepool/2020/10-10thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_10_10thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201112-to-20201116";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201112-to-20201116";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201112";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201115";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201116";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201112";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201115";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201116";
 
 
     public int numberofgames;

--- a/thepool/2020/11-eleventhwk.aspx.cs
+++ b/thepool/2020/11-eleventhwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_11_eleventhwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201119-to-20201123";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201119-to-20201123";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201119";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201122";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201123";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201119";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201122";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201123";
 
 
     public int numberofgames;

--- a/thepool/2020/12-covid.aspx.cs
+++ b/thepool/2020/12-covid.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_12_covid : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201126-to-20201201";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201126-to-20201201";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201126";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201129";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201130";
-    // public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201201";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201126";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201129";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201130";
+    // public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201201";
 
 
     public int numberofgames;

--- a/thepool/2020/12-thanksgiving.aspx.cs
+++ b/thepool/2020/12-thanksgiving.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_12_thanksgiving : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201126-to-20201202";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201126-to-20201202";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201126";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201129";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201130";
-    public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201202";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201126";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201129";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201130";
+    public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201202";
 
 
     public int numberofgames;

--- a/thepool/2020/13-13thweek.aspx.cs
+++ b/thepool/2020/13-13thweek.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_13_13thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201206-to-20201208";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201206-to-20201208";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    //public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201203";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201206";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201207";
-    public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201208";
+    //public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201203";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201206";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201207";
+    public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201208";
 
 
     public int numberofgames;

--- a/thepool/2020/14-wk14.aspx.cs
+++ b/thepool/2020/14-wk14.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_14_wk14 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201210-to-20201214";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201210-to-20201214";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201210";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201213";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201214";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201210";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201213";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201214";
 
 
     public int numberofgames;

--- a/thepool/2020/15-week15.aspx.cs
+++ b/thepool/2020/15-week15.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_15_week15 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201217-to-20201221";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201217-to-20201221";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201217";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201220";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201221";
-    public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201219";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201217";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201220";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201221";
+    public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201219";
 
 
     public int numberofgames;

--- a/thepool/2020/16-christmas.aspx.cs
+++ b/thepool/2020/16-christmas.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_16_christmas : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201225-to-20201228";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201225-to-20201228";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201225";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201227";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201228";
-    public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201226";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201225";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201227";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201228";
+    public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201226";
 
 
     public int numberofgames;

--- a/thepool/2020/17-2020wk17.aspx.cs
+++ b/thepool/2020/17-2020wk17.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2020_17_2020wk17 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20210103-to-20210103";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20210103-to-20210103";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    //public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201225";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20210103";
-    //public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201228";
-    //public string urlscoreswk1pt4 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201226";
+    //public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201225";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20210103";
+    //public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201228";
+    //public string urlscoreswk1pt4 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201226";
 
 
     public int numberofgames;

--- a/thepool/2021/00-infocheck.aspx.cs
+++ b/thepool/2021/00-infocheck.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_00_infocheck : System.Web.UI.Page
 {
-    public string urlwk = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscores = "https://api.mysportsfeeds.com/v2.1/pull/nfl/2020-2021-regular/week/4/games.json";
-    // public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201004";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201005";
+    public string urlscores = $"{CredentialStore.ApiBaseUrlV2}/2020-2021-regular/week/4/games.json";
+    // public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201004";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201005";
 
 
     public int numberofgames;

--- a/thepool/2021/01-wk1-2021.aspx.cs
+++ b/thepool/2021/01-wk1-2021.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_01_wk1_2021 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20210909-to-20210913";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20210909-to-20210913";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210909";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210912";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210913";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210909";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210912";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210913";
 
 
     public int numberofgames;

--- a/thepool/2021/02-secondweek.aspx.cs
+++ b/thepool/2021/02-secondweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_02_secondweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20210916-to-20210920";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20210916-to-20210920";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210916";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210919";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210920";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210916";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210919";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210920";
 
 
     public int numberofgames;

--- a/thepool/2021/03-3rd-week.aspx.cs
+++ b/thepool/2021/03-3rd-week.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_03_3rd_week : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20210923-to-20210927";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20210923-to-20210927";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210923";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210926";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210927";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210923";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210926";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210927";
 
 
     public int numberofgames;

--- a/thepool/2021/04-the4thwk.aspx.cs
+++ b/thepool/2021/04-the4thwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_04_the4thwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20210930-to-20211004";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20210930-to-20211004";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20210930";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211003";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211004";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20210930";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211003";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211004";
 
 
     public int numberofgames;

--- a/thepool/2021/05-fifthweek21.aspx.cs
+++ b/thepool/2021/05-fifthweek21.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_05_fifthweek21 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211007-to-20211011";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211007-to-20211011";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211007";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211010";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211011";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211007";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211010";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211011";
 
 
     public int numberofgames;

--- a/thepool/2021/06-weeksix.aspx.cs
+++ b/thepool/2021/06-weeksix.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_06_weeksix : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211014-to-20211018";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211014-to-20211018";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211014";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211017";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211018";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211014";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211017";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211018";
 
 
     public int numberofgames;

--- a/thepool/2021/07-7thweek.aspx.cs
+++ b/thepool/2021/07-7thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_07_7thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211021-to-20211025";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211021-to-20211025";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211021";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211024";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211025";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211021";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211024";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211025";
 
 
     public int numberofgames;

--- a/thepool/2021/08-wk8.aspx.cs
+++ b/thepool/2021/08-wk8.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_08_wk8 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211028-to-20211101";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211028-to-20211101";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211028";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211031";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211101";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211028";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211031";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211101";
 
 
     public int numberofgames;

--- a/thepool/2021/09-ninthwk.aspx.cs
+++ b/thepool/2021/09-ninthwk.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_09_ninthwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211104-to-20211108";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211104-to-20211108";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211104";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211107";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211108";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211104";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211107";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211108";
 
 
     public int numberofgames;

--- a/thepool/2021/10-week10.aspx.cs
+++ b/thepool/2021/10-week10.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_10_week10 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211111-to-20211115";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211111-to-20211115";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211111";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211114";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211115";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211111";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211114";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211115";
 
 
     public int numberofgames;

--- a/thepool/2021/11-11thweek.aspx.cs
+++ b/thepool/2021/11-11thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_11_11thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211118-to-20211122";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211118-to-20211122";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211118";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211121";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211122";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211118";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211121";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211122";
 
 
     public int numberofgames;

--- a/thepool/2021/12-thxgiv.aspx.cs
+++ b/thepool/2021/12-thxgiv.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_12_thxgiv : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211125-to-20211129";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211125-to-20211129";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211125";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211128";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211129";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211125";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211128";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211129";
 
 
     public int numberofgames;

--- a/thepool/2021/13-13thweek.aspx.cs
+++ b/thepool/2021/13-13thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_13_13thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211202-to-20211206";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211202-to-20211206";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211202";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211205";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211206";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211202";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211205";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211206";
 
 
     public int numberofgames;

--- a/thepool/2021/14-wk14.aspx.cs
+++ b/thepool/2021/14-wk14.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2021_14_wk14 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211209-to-20211213";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211209-to-20211213";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211209";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112012";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112013";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211209";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112012";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112013";
 
 
     public int numberofgames;

--- a/thepool/2021/15-weekbeforexmas.aspx.cs
+++ b/thepool/2021/15-weekbeforexmas.aspx.cs
@@ -16,14 +16,14 @@ using System.Collections.Specialized;
 
 public partial class _2021_15_weekbeforexmas : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211216-to-20211221";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211216-to-20211221";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211216";
-    public string urlscoreswk1sat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211218";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112019";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112020";
-    public string urlscoreswk1tue = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112021";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211216";
+    public string urlscoreswk1sat = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211218";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112019";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112020";
+    public string urlscoreswk1tue = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112021";
 
 
     public int numberofgames;

--- a/thepool/2021/16-xmas.aspx.cs
+++ b/thepool/2021/16-xmas.aspx.cs
@@ -16,14 +16,14 @@ using System.Collections.Specialized;
 
 public partial class _2021_16_xmas : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20211223-to-20211227";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20211223-to-20211227";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211223";
-    public string urlscoreswk1sat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211225";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112026";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112027";
-    //public string urlscoreswk1tue = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112021";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211223";
+    public string urlscoreswk1sat = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211225";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112026";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112027";
+    //public string urlscoreswk1tue = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112021";
 
 
     public int numberofgames;

--- a/thepool/2021/17-newyear.aspx.cs
+++ b/thepool/2021/17-newyear.aspx.cs
@@ -16,14 +16,14 @@ using System.Collections.Specialized;
 
 public partial class _2021_17_newyear : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20220102-to-20220103";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20220102-to-20220103";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    //public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211223";
-    //public string urlscoreswk1sat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211225";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20220102";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20220103";
-    //public string urlscoreswk1tue = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112021";
+    //public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211223";
+    //public string urlscoreswk1sat = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211225";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20220102";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20220103";
+    //public string urlscoreswk1tue = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112021";
 
 
     public int numberofgames;

--- a/thepool/2021/18-18thwk2021.aspx.cs
+++ b/thepool/2021/18-18thwk2021.aspx.cs
@@ -16,14 +16,14 @@ using System.Collections.Specialized;
 
 public partial class _2021_18_18thwk2021 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/full_game_schedule.json?date=from-20220108-to-20220109";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/full_game_schedule.json?date=from-20220108-to-20220109";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20220108";
-    //public string urlscoreswk1sat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20211225";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20220109";
-    //public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=20220103";
-    //public string urlscoreswk1tue = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2021-regular/scoreboard.json?fordate=202112021";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20220108";
+    //public string urlscoreswk1sat = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20211225";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20220109";
+    //public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=20220103";
+    //public string urlscoreswk1tue = $"{CredentialStore.ApiBaseUrl}/2021-regular/scoreboard.json?fordate=202112021";
 
 
     public int numberofgames;

--- a/thepool/2023/00-infocheck.aspx.cs
+++ b/thepool/2023/00-infocheck.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2020_00_infocheck : System.Web.UI.Page
 {
-    public string urlwk = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk = $"{CredentialStore.ApiBaseUrl}/2020-regular/full_game_schedule.json?date=from-20201001-to-20201005";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscores = "https://api.mysportsfeeds.com/v2.1/pull/nfl/2020-2021-regular/week/4/games.json";
-    // public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201004";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-regular/scoreboard.json?fordate=20201005";
+    public string urlscores = $"{CredentialStore.ApiBaseUrlV2}/2020-2021-regular/week/4/games.json";
+    // public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201004";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2020-regular/scoreboard.json?fordate=20201005";
 
 
     public int numberofgames;

--- a/thepool/2023/01-2023-wk1.aspx.cs
+++ b/thepool/2023/01-2023-wk1.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_01_2023_wk1 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20230907-to-20230911";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20230907-to-20230911";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230907";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230910";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230911";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230907";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230910";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230911";
 
 
     public int numberofgames;

--- a/thepool/2023/02-secondwk23.aspx.cs
+++ b/thepool/2023/02-secondwk23.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_02_secondwk23 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20230914-to-20230918";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20230914-to-20230918";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230914";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230917";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230918";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230914";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230917";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230918";
 
 
     public int numberofgames;

--- a/thepool/2023/03-week3.aspx.cs
+++ b/thepool/2023/03-week3.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_03_week3 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20230921-to-20230925";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20230921-to-20230925";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230921";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230924";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230925";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230921";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230924";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230925";
 
 
     public int numberofgames;

--- a/thepool/2023/04-4thweek23.aspx.cs
+++ b/thepool/2023/04-4thweek23.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_04_4thweek23 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20230928-to-20231002";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20230928-to-20231002";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20230928";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231001";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231002";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20230928";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231001";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231002";
 
 
     public int numberofgames;

--- a/thepool/2023/05-byeweek1.aspx.cs
+++ b/thepool/2023/05-byeweek1.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_05_byeweek1 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231005-to-20231009";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231005-to-20231009";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231005";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231008";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231009";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231005";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231008";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231009";
 
 
     public int numberofgames;

--- a/thepool/2023/06-6thwk23.aspx.cs
+++ b/thepool/2023/06-6thwk23.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_06_6thwk23 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231012-to-20231016";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231012-to-20231016";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231012";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231015";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231016";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231012";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231015";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231016";
 
 
     public int numberofgames;

--- a/thepool/2023/07-week7.aspx.cs
+++ b/thepool/2023/07-week7.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_07_week7 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231019-to-20231023";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231019-to-20231023";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231019";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231022";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231023";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231019";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231022";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231023";
 
 
     public int numberofgames;

--- a/thepool/2023/08-8thweek.aspx.cs
+++ b/thepool/2023/08-8thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_08_8thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231026-to-20231030";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231026-to-20231030";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231026";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231029";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231030";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231026";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231029";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231030";
 
 
     public int numberofgames;

--- a/thepool/2023/09-ninth2023.aspx.cs
+++ b/thepool/2023/09-ninth2023.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_09_ninth2023 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231102-to-20231106";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231102-to-20231106";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231102";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231105";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231106";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231102";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231105";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231106";
 
 
     public int numberofgames;

--- a/thepool/2023/10-the10thweek.aspx.cs
+++ b/thepool/2023/10-the10thweek.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_10_the10thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231109-to-20231113";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231109-to-20231113";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231109";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231112";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231113";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231109";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231112";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231113";
 
 
     public int numberofgames;

--- a/thepool/2023/11-eleven.aspx.cs
+++ b/thepool/2023/11-eleven.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_11_eleven : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231116-to-20231120";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231116-to-20231120";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231116";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231119";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231120";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231116";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231119";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231120";
 
 
     public int numberofgames;

--- a/thepool/2023/12-thanksgiving23.aspx.cs
+++ b/thepool/2023/12-thanksgiving23.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2023_12_thanksgiving23 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231123-to-20231127";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231123-to-20231127";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231123";
-    public string urlscoreswk1ptfri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231124";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231126";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231127";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231123";
+    public string urlscoreswk1ptfri = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231124";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231126";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231127";
 
 
     public int numberofgames;

--- a/thepool/2023/13-week13.aspx.cs
+++ b/thepool/2023/13-week13.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_13_week13 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231130-to-20231204";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231130-to-20231204";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231130";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231203";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231204";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231130";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231203";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231204";
 
 
     public int numberofgames;

--- a/thepool/2023/14-fourteen.aspx.cs
+++ b/thepool/2023/14-fourteen.aspx.cs
@@ -16,12 +16,12 @@ using System.Collections.Specialized;
 
 public partial class _2023_14_fourteen : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231207-to-20231211";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231207-to-20231211";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231207";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231210";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231211";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231207";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231210";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231211";
 
 
     public int numberofgames;

--- a/thepool/2023/15-fifteenthwk.aspx.cs
+++ b/thepool/2023/15-fifteenthwk.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2023_15_fifteenthwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231214-to-20231218";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231214-to-20231218";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231214";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231216"; 
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231217";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231218";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231214";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231216"; 
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231217";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231218";
 
 
     public int numberofgames;

--- a/thepool/2023/16-the16thweek.aspx.cs
+++ b/thepool/2023/16-the16thweek.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2023_16_the16thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231221-to-20231225";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231221-to-20231225";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231221";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231223";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231224";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231225";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231221";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231223";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231224";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231225";
 
 
     public int numberofgames;

--- a/thepool/2023/17-wk17.aspx.cs
+++ b/thepool/2023/17-wk17.aspx.cs
@@ -16,13 +16,13 @@ using System.Collections.Specialized;
 
 public partial class _2023_17_wk17 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20231228-to-20231231";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20231228-to-20231231";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231228";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231230";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231231";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231225";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231228";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231230";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231231";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231225";
 
 
     public int numberofgames;

--- a/thepool/2023/18-the18thweek.aspx.cs
+++ b/thepool/2023/18-the18thweek.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2023_18_the18thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/full_game_schedule.json?date=from-20240106-to-20240107";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/full_game_schedule.json?date=from-20240106-to-20240107";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    //public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231228";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20240106";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20240107";
-    // public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2023-regular/scoreboard.json?fordate=20231225";
+    //public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231228";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20240106";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20240107";
+    // public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2023-regular/scoreboard.json?fordate=20231225";
 
 
     public int numberofgames;

--- a/thepool/2024/01-firstwk24.aspx.cs
+++ b/thepool/2024/01-firstwk24.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_01_firstwk24 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20240905-to-20240909";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20240905-to-20240909";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240905";
-    public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240908";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240909";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240905";
+    public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240908";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240909";
 
 
     public int numberofgames;

--- a/thepool/2024/02-weektwo.aspx.cs
+++ b/thepool/2024/02-weektwo.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_02_weektwo : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20240912-to-20240916";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20240912-to-20240916";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240912";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240915";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240916";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240912";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240915";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240916";
 
 
     public int numberofgames;

--- a/thepool/2024/03-3rdweek.aspx.cs
+++ b/thepool/2024/03-3rdweek.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_03_3rdweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20240919-to-20240923";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20240919-to-20240923";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240919";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240922";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240923";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240919";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240922";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240923";
 
 
     public int numberofgames;

--- a/thepool/2024/04-week4.aspx.cs
+++ b/thepool/2024/04-week4.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_04_week4 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20240926-to-20240930";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20240926-to-20240930";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240926";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240929";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240930";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240926";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240929";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240930";
 
 
     public int numberofgames;

--- a/thepool/2024/05-5thwk24.aspx.cs
+++ b/thepool/2024/05-5thwk24.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_05_5thwk24 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241003-to-20241007";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241003-to-20241007";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241003";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241006";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241007";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241003";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241006";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241007";
 
 
     public int numberofgames;

--- a/thepool/2024/06-wk6.aspx.cs
+++ b/thepool/2024/06-wk6.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_06_wk6 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241010-to-20241014";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241010-to-20241014";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241010";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241013";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241014";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241010";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241013";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241014";
 
 
     public int numberofgames;

--- a/thepool/2024/07-seventhwk.aspx.cs
+++ b/thepool/2024/07-seventhwk.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_07_seventhwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241017-to-20241021";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241017-to-20241021";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241017";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241020";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241021";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241017";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241020";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241021";
 
 
     public int numberofgames;

--- a/thepool/2024/08-halloween.aspx.cs
+++ b/thepool/2024/08-halloween.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_08_halloween : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241024-to-20241028";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241024-to-20241028";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241024";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241027";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241028";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241024";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241027";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241028";
 
 
     public int numberofgames;

--- a/thepool/2024/09-weeknine24.aspx.cs
+++ b/thepool/2024/09-weeknine24.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_09_weeknine24 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241031-to-20241104";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241031-to-20241104";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241031";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241101";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241103";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241104";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241031";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241101";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241103";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241104";
 
 
     public int numberofgames;

--- a/thepool/2024/10-tenth.aspx.cs
+++ b/thepool/2024/10-tenth.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_10_tenth : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241107-to-20241111";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241107-to-20241111";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241107";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241110";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241111";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241107";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241110";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241111";
 
 
     public int numberofgames;

--- a/thepool/2024/11-eleventhwk.aspx.cs
+++ b/thepool/2024/11-eleventhwk.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_11_eleventhwk : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241114-to-20241118";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241114-to-20241118";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241114";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241117";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241118";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241114";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241117";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241118";
 
 
     public int numberofgames;

--- a/thepool/2024/12-the12thweek.aspx.cs
+++ b/thepool/2024/12-the12thweek.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_12_the12thweek : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241121-to-20241125";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241121-to-20241125";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241121";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241124";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241125";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241121";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241124";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241125";
 
 
     public int numberofgames;

--- a/thepool/2024/13-tgiving24.aspx.cs
+++ b/thepool/2024/13-tgiving24.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_13_tgiving24 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241128-to-20241202";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241128-to-20241202";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241128";
-    public string urlscoreswk1ptfri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241129";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241201";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241202";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241128";
+    public string urlscoreswk1ptfri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241129";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241201";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241202";
 
 
     public int numberofgames;

--- a/thepool/2024/14-week14.aspx.cs
+++ b/thepool/2024/14-week14.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_14_week14 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241205-to-20241209";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241205-to-20241209";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241205";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241208";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241209";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241205";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241208";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241209";
 
 
     public int numberofgames;

--- a/thepool/2024/15-fifteenth24.aspx.cs
+++ b/thepool/2024/15-fifteenth24.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_15_fifteenth24 : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241212-to-20241216";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241212-to-20241216";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241212";
-    // public string urlscoreswk1fri = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20240906";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241215";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241216";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241212";
+    // public string urlscoreswk1fri = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20240906";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241215";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241216";
 
 
     public int numberofgames;

--- a/thepool/2024/16-week16th.aspx.cs
+++ b/thepool/2024/16-week16th.aspx.cs
@@ -17,13 +17,13 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_16_week16th : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241219-to-20241223";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241219-to-20241223";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241219";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241221";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241222";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241223";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241219";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241221";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241222";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241223";
 
 
     public int numberofgames;

--- a/thepool/2024/17-10gamescount.aspx.cs
+++ b/thepool/2024/17-10gamescount.aspx.cs
@@ -17,14 +17,14 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_17_10gamescount : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241225-to-20241230";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241225-to-20241230";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1xmas = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241225";
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241226";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241228";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241229";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241230";
+    public string urlscoreswk1xmas = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241225";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241226";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241228";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241229";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241230";
 
 
     public int numberofgames;

--- a/thepool/2024/18-happynewyear.aspx.cs
+++ b/thepool/2024/18-happynewyear.aspx.cs
@@ -17,14 +17,14 @@ using MySql.Data.MySqlClient;
 
 public partial class _2024_18_happynewyear : System.Web.UI.Page
 {
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    //public string urlscoreswk1xmas = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241225";
-    //public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241226";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20250104";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20250105";
-    //public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241230";
+    //public string urlscoreswk1xmas = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241225";
+    //public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241226";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20250104";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20250105";
+    //public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241230";
 
 
     public int numberofgames;

--- a/thepool/App_Code/CredentialStore.cs
+++ b/thepool/App_Code/CredentialStore.cs
@@ -40,6 +40,11 @@ public static class CredentialStore
             Environment.GetEnvironmentVariable("POOL_API_BASE_URL") ??
             ConfigurationManager.AppSettings["ApiBaseUrl"];
 
+        public static string ApiBaseUrlV2 =>
+            Environment.GetEnvironmentVariable("POOL_API_BASE_URL_V2") ??
+            ConfigurationManager.AppSettings["ApiBaseUrlV2"] ??
+            ApiBaseUrl;
+
         public static string SmtpHost =>
             Environment.GetEnvironmentVariable("POOL_SMTP_HOST") ??
             ConfigurationManager.AppSettings["SmtpHost"];

--- a/thepool/Default.aspx.cs
+++ b/thepool/Default.aspx.cs
@@ -23,7 +23,7 @@ using MySql.Data.MySqlClient;
 public partial class _Default : System.Web.UI.Page
 {
     public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20250104-to-20250105";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-2021-regular/overall_team_standings.json";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2020-2021-regular/overall_team_standings.json";
 
     public int numberofgames;
     public int numberofteams;
@@ -78,10 +78,10 @@ public partial class _Default : System.Web.UI.Page
 
         // var listItems = new List<currentstandings>();
         // var client = new WebClient();
-        // var text = client.DownloadString("https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20170907-to-20170910");
+        // var text = client.DownloadString($"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20170907-to-20170910");
         // nflgames showall = JsonConvert.DeserializeObject<nflgames>(text);
         
-        // string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
+        // string url = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
         // WebRequest request = WebRequest.Create(url);
         // request.Credentials = GetCredential();
         // request.PreAuthenticate = true;

--- a/thepool/Web.config.example
+++ b/thepool/Web.config.example
@@ -14,6 +14,7 @@
     <add key="CcAddress" value="cc@example.com" />
     <add key="BaseUrl" value="REPLACE_WITH_http://www.website.com" />
     <add key="ApiBaseUrl" value="REPLACE_WITH_https://api.website.com/v1.1/pull/nfl" />
+    <add key="ApiBaseUrlV2" value="REPLACE_WITH_https://api.website.com/v2.1/pull/nfl" />
     <add key="SmtpHost" value="REPLACE_WITH_mail16.website.com" />
   </appSettings>
   <system.web>

--- a/thepool/add-picks.aspx.cs
+++ b/thepool/add-picks.aspx.cs
@@ -17,7 +17,7 @@ using MySql.Data.MySqlClient;
 public partial class add_picks : System.Web.UI.Page
 {
     public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241003-to-20241007";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2020-2021-regular/overall_team_standings.json";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2020-2021-regular/overall_team_standings.json";
 
     public int numberofgames;
     public int numberofteams;
@@ -72,10 +72,10 @@ public partial class add_picks : System.Web.UI.Page
 
         // var listItems = new List<currentstandings>();
         // var client = new WebClient();
-        // var text = client.DownloadString("https://api.mysportsfeeds.com/v1.1/pull/nfl/2018-regular/full_game_schedule.json?date=from-20170907-to-20170910");
+        // var text = client.DownloadString($"{CredentialStore.ApiBaseUrl}/2018-regular/full_game_schedule.json?date=from-20170907-to-20170910");
         // nflgames showall = JsonConvert.DeserializeObject<nflgames>(text);
 
-        // string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
+        // string url = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
         // WebRequest request = WebRequest.Create(url);
         // request.Credentials = GetCredential();
         // request.PreAuthenticate = true;

--- a/thepool/scoreboard/scoresInsert.aspx.cs
+++ b/thepool/scoreboard/scoresInsert.aspx.cs
@@ -20,14 +20,14 @@ public partial class scoreboard_scoresInsert : System.Web.UI.Page
 
     // Copy from weekly cs file below
 
-    public string urlwk2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/full_game_schedule.json?date=from-20241225-to-20241230";
-    // public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/full_game_schedule.json?date=from-20241225-to-20241230";
+    // public string urlts = $"{CredentialStore.ApiBaseUrl}/2016-2017-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
-    public string urlscoreswk1xmas = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241225";
-    public string urlscoreswk1pt1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241226";
-    public string urlscoreswk1ptsat = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241228";
-    public string urlscoreswk1pt2 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241229";
-    public string urlscoreswk1pt3 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2024-regular/scoreboard.json?fordate=20241230";
+    public string urlscoreswk1xmas = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241225";
+    public string urlscoreswk1pt1 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241226";
+    public string urlscoreswk1ptsat = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241228";
+    public string urlscoreswk1pt2 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241229";
+    public string urlscoreswk1pt3 = $"{CredentialStore.ApiBaseUrl}/2024-regular/scoreboard.json?fordate=20241230";
 
 
     public int numberofgames;

--- a/thepool/thepool/Default.aspx.cs
+++ b/thepool/thepool/Default.aspx.cs
@@ -21,8 +21,8 @@ using System.Collections.Specialized;
 
 public partial class _Default : System.Web.UI.Page
 {
-    public string urlwk1 = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
-    public string urlts = "https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-2018-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
+    public string urlwk1 = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
+    public string urlts = $"{CredentialStore.ApiBaseUrl}/2017-2018-regular/overall_team_standings.json?teamstats=W,L,T,PF,PA";
 
     public int numberofgames;
     public int numberofteams;
@@ -77,10 +77,10 @@ public partial class _Default : System.Web.UI.Page
 
         // var listItems = new List<currentstandings>();
         // var client = new WebClient();
-        // var text = client.DownloadString("https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170907-to-20170910");
+        // var text = client.DownloadString($"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170907-to-20170910");
         // nflgames showall = JsonConvert.DeserializeObject<nflgames>(text);
         
-        // string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
+        // string url = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20170907-to-20170911?limit=1";
         // WebRequest request = WebRequest.Create(url);
         // request.Credentials = GetCredential();
         // request.PreAuthenticate = true;
@@ -313,7 +313,7 @@ public partial class _Default : System.Web.UI.Page
 
     private CredentialCache GetCredential()
     {
-        string url = @"https://api.mysportsfeeds.com/v1.1/pull/nfl/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
+        string url = $"{CredentialStore.ApiBaseUrl}/2017-regular/full_game_schedule.json?date=from-20171109-to-20171113";
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
         CredentialCache credentialCache = new CredentialCache();
         credentialCache.Add(new System.Uri(url), "Basic", CredentialStore.ApiCredential);


### PR DESCRIPTION
## Summary
- Replace hard-coded sports feed URLs with references to `CredentialStore.ApiBaseUrl`
- Add `ApiBaseUrlV2` for newer API version and update sample config
- Update all pages to use the centralized API base

## Testing
- ⚠️ `dotnet build website.publishproj` *(dotnet: command not found)*
- ⚠️ `msbuild website.publishproj` *(msbuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4249d9c883319964e179d33a48f5